### PR TITLE
add aria-label for URL picker and related components

### DIFF
--- a/src/gutenberg/blocks/button-single/block.json
+++ b/src/gutenberg/blocks/button-single/block.json
@@ -21,6 +21,12 @@
       "selector": "a.ghostkit-button",
       "attribute": "href"
     },
+    "ariaLabel": {
+      "type": "string",
+      "source": "attribute",
+      "selector": "a.ghostkit-button",
+      "attribute": "aria-label"
+    },
     "target": {
       "type": "string",
       "source": "attribute",

--- a/src/gutenberg/blocks/button-single/deprecated.js
+++ b/src/gutenberg/blocks/button-single/deprecated.js
@@ -1,0 +1,183 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames/dedupe';
+
+/**
+ * Internal dependencies
+ */
+import IconPicker from '../../components/icon-picker';
+
+import metadata from './block.json';
+
+/**
+ * WordPress dependencies
+ */
+const { applyFilters } = wp.hooks;
+
+const { RichText, useBlockProps } = wp.blockEditor;
+
+const { name } = metadata;
+
+export default [
+  // v2.23.2
+  {
+    ...metadata,
+
+    attributes: {
+      tagName: {
+        type: 'string',
+      },
+      url: {
+        type: 'string',
+        source: 'attribute',
+        selector: 'a.ghostkit-button',
+        attribute: 'href',
+      },
+      target: {
+        type: 'string',
+        source: 'attribute',
+        selector: 'a.ghostkit-button',
+        attribute: 'target',
+      },
+      rel: {
+        type: 'string',
+        source: 'attribute',
+        selector: 'a.ghostkit-button',
+        attribute: 'rel',
+      },
+      text: {
+        type: 'string',
+        source: 'html',
+        selector: '.ghostkit-button .ghostkit-button-text',
+        default: 'Button',
+      },
+      hideText: {
+        type: 'boolean',
+        default: false,
+      },
+      icon: {
+        type: 'string',
+        default: '',
+      },
+      iconPosition: {
+        type: 'string',
+        default: 'left',
+      },
+      size: {
+        type: 'string',
+        default: 'md',
+      },
+      color: {
+        type: 'string',
+      },
+      textColor: {
+        type: 'string',
+      },
+
+      borderRadius: {
+        type: 'number',
+      },
+      borderWeight: {
+        type: 'number',
+      },
+      borderColor: {
+        type: 'string',
+      },
+
+      focusOutlineWeight: {
+        type: 'number',
+      },
+
+      hoverColor: {
+        type: 'string',
+      },
+      hoverTextColor: {
+        type: 'string',
+      },
+      hoverBorderColor: {
+        type: 'string',
+      },
+
+      focusOutlineColor: {
+        type: 'string',
+        default: 'rgba(3, 102, 214, 0.5)',
+      },
+    },
+    save: function BlockSave(props) {
+      const {
+        tagName,
+        text,
+        icon,
+        iconPosition,
+        hideText,
+        url,
+        target,
+        rel,
+        size,
+        focusOutlineWeight,
+        focusOutlineColor,
+      } = props.attributes;
+
+      let className = classnames(
+        'ghostkit-button',
+        size ? `ghostkit-button-${size}` : '',
+        hideText ? 'ghostkit-button-icon-only' : ''
+      );
+
+      // focus outline
+      if (focusOutlineWeight && focusOutlineColor) {
+        className = classnames(className, 'ghostkit-button-with-outline');
+      }
+
+      className = applyFilters('ghostkit.blocks.className', className, {
+        ...{
+          name,
+        },
+        ...props,
+      });
+
+      const result = [];
+
+      if (!hideText) {
+        result.push(
+          <RichText.Content
+            tagName="span"
+            className="ghostkit-button-text"
+            value={text}
+            key="button-text"
+          />
+        );
+      }
+
+      // add icon.
+      if (icon) {
+        result.unshift(
+          <IconPicker.Render
+            name={icon}
+            tag="span"
+            className={`ghostkit-button-icon ghostkit-button-icon-${
+              'right' === iconPosition ? 'right' : 'left'
+            }`}
+            key="button-icon"
+          />
+        );
+      }
+
+      const Tag = tagName || (url ? 'a' : 'span');
+
+      const blockProps = useBlockProps.save({
+        className,
+        ...('a' === Tag
+          ? {
+              href: url,
+              target: target || false,
+              rel: rel || false,
+            }
+          : {}),
+      });
+
+      return <Tag {...blockProps}>{result}</Tag>;
+    },
+  },
+];

--- a/src/gutenberg/blocks/button-single/edit.js
+++ b/src/gutenberg/blocks/button-single/edit.js
@@ -62,6 +62,7 @@ class BlockEdit extends Component {
       iconPosition,
       hideText,
       url,
+      ariaLabel,
       target,
       rel,
       size,
@@ -362,6 +363,7 @@ class BlockEdit extends Component {
           <URLPicker
             url={url}
             rel={rel}
+            ariaLabel={ariaLabel}
             target={target}
             onChange={(data) => {
               setAttributes(data);

--- a/src/gutenberg/blocks/button-single/index.js
+++ b/src/gutenberg/blocks/button-single/index.js
@@ -6,6 +6,7 @@ import getIcon from '../../utils/get-icon';
 import metadata from './block.json';
 import edit from './edit';
 import save from './save';
+import deprecated from './deprecated';
 
 const { name } = metadata;
 
@@ -59,4 +60,5 @@ export const settings = {
   },
   edit,
   save,
+  deprecated,
 };

--- a/src/gutenberg/blocks/button-single/save.js
+++ b/src/gutenberg/blocks/button-single/save.js
@@ -33,6 +33,7 @@ class BlockSave extends Component {
       iconPosition,
       hideText,
       url,
+      ariaLabel,
       target,
       rel,
       size,
@@ -92,7 +93,7 @@ class BlockSave extends Component {
     }
 
     return 'a' === Tag ? (
-      <Tag className={className} href={url} target={target || false} rel={rel || false}>
+      <Tag className={className} href={url} aria-label={ariaLabel || ''} target={target || false} rel={rel || false}>
         {result}
       </Tag>
     ) : (

--- a/src/gutenberg/blocks/button-single/save.js
+++ b/src/gutenberg/blocks/button-single/save.js
@@ -90,9 +90,9 @@ export default function BlockSave(props) {
     ...('a' === Tag
       ? {
           href: url,
-          target: target || false,
-          rel: rel || false,
-          'aria-label': ariaLabel || false,
+          target: target || null,
+          rel: rel || null,
+          'aria-label': ariaLabel || null,
         }
       : {}),
   });

--- a/src/gutenberg/blocks/counter-box/block.json
+++ b/src/gutenberg/blocks/counter-box/block.json
@@ -45,6 +45,10 @@
     "url": {
       "type": "string"
     },
+    "ariaLabel": {
+      "type": "string",
+      "default": ""
+    },
     "target": {
       "type": "string"
     },

--- a/src/gutenberg/blocks/counter-box/block.json
+++ b/src/gutenberg/blocks/counter-box/block.json
@@ -49,8 +49,7 @@
       "type": "string"
     },
     "ariaLabel": {
-      "type": "string",
-      "default": ""
+      "type": "string"
     },
     "target": {
       "type": "string"

--- a/src/gutenberg/blocks/counter-box/deprecated.js
+++ b/src/gutenberg/blocks/counter-box/deprecated.js
@@ -23,6 +23,48 @@ export default [
   // v2.23.2
   {
     ...metadata,
+    attributes: {
+      number: {
+        type: 'string',
+        source: 'html',
+        selector: '.ghostkit-counter-box-number-wrap',
+        default: '77',
+      },
+      animateInViewport: {
+        type: 'boolean',
+        default: false,
+      },
+      animateInViewportFrom: {
+        type: 'number',
+        default: 0,
+      },
+      numberPosition: {
+        type: 'string',
+        default: 'top',
+      },
+      numberSize: {
+        type: 'number',
+      },
+      showContent: {
+        type: 'boolean',
+        default: true,
+      },
+      numberColor: {
+        type: 'string',
+      },
+      hoverNumberColor: {
+        type: 'string',
+      },
+      url: {
+        type: 'string',
+      },
+      target: {
+        type: 'string',
+      },
+      rel: {
+        type: 'string',
+      },
+    },
     save: class BlockSave extends Component {
       render() {
         const { number, animateInViewport, numberPosition, showContent, url, target, rel } =

--- a/src/gutenberg/blocks/counter-box/edit.js
+++ b/src/gutenberg/blocks/counter-box/edit.js
@@ -55,6 +55,7 @@ class BlockEdit extends Component {
       numberColor,
       hoverNumberColor,
       url,
+      ariaLabel,
       target,
       rel,
     } = attributes;
@@ -172,6 +173,7 @@ class BlockEdit extends Component {
         <URLPicker
           url={url}
           rel={rel}
+          ariaLabel={ariaLabel}
           target={target}
           onChange={(data) => {
             setAttributes(data);

--- a/src/gutenberg/blocks/counter-box/save.js
+++ b/src/gutenberg/blocks/counter-box/save.js
@@ -62,9 +62,9 @@ class BlockSave extends Component {
           <a
             className="ghostkit-counter-box-link"
             href={url}
-            target={target || false}
-            rel={rel || false}
-            aria-label={ariaLabel || false}
+            target={target || null}
+            rel={rel || null}
+            aria-label={ariaLabel || null}
           >
             <span />
           </a>

--- a/src/gutenberg/blocks/counter-box/save.js
+++ b/src/gutenberg/blocks/counter-box/save.js
@@ -24,7 +24,7 @@ const { name } = metadata;
  */
 class BlockSave extends Component {
   render() {
-    const { number, animateInViewport, numberPosition, showContent, url, target, rel } =
+    const { number, animateInViewport, numberPosition, showContent, url, ariaLabel, target, rel } =
       this.props.attributes;
 
     let { animateInViewportFrom } = this.props.attributes;
@@ -48,6 +48,7 @@ class BlockSave extends Component {
             href={url}
             target={target || false}
             rel={rel || false}
+            aria-label={ariaLabel || ''}
           >
             <span />
           </a>

--- a/src/gutenberg/blocks/icon-box/block.json
+++ b/src/gutenberg/blocks/icon-box/block.json
@@ -35,6 +35,10 @@
     "url": {
       "type": "string"
     },
+    "ariaLabel": {
+      "type": "string",
+      "default": ""
+    },
     "target": {
       "type": "string"
     },

--- a/src/gutenberg/blocks/icon-box/block.json
+++ b/src/gutenberg/blocks/icon-box/block.json
@@ -39,8 +39,7 @@
       "type": "string"
     },
     "ariaLabel": {
-      "type": "string",
-      "default": ""
+      "type": "string"
     },
     "target": {
       "type": "string"

--- a/src/gutenberg/blocks/icon-box/deprecated.js
+++ b/src/gutenberg/blocks/icon-box/deprecated.js
@@ -25,6 +25,39 @@ export default [
   // v2.23.2
   {
     ...metadata,
+    attributes: {
+      icon: {
+        type: 'string',
+        default:
+          '%3Csvg%20class%3D%22ghostkit-svg-icon%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M16.7813%209.75C16.7813%207.10939%2014.6406%204.96875%2012%204.96875C9.35939%204.96875%207.21875%207.10939%207.21875%209.75C7.21875%2012.3906%209.35939%2014.5312%2012%2014.5312C14.6406%2014.5312%2016.7813%2012.3906%2016.7813%209.75Z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%2F%3E%3Cpath%20d%3D%22M8.15625%2018C10.6023%2019.25%2013.3977%2019.25%2015.8437%2018%22%20stroke%3D%22currentColor%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22%2F%3E%3C%2Fsvg%3E',
+      },
+      iconPosition: {
+        type: 'string',
+        default: 'left',
+      },
+      iconSize: {
+        type: 'number',
+      },
+      showContent: {
+        type: 'boolean',
+        default: true,
+      },
+      iconColor: {
+        type: 'string',
+      },
+      hoverIconColor: {
+        type: 'string',
+      },
+      url: {
+        type: 'string',
+      },
+      target: {
+        type: 'string',
+      },
+      rel: {
+        type: 'string',
+      },
+    },
     save: class BlockSave extends Component {
       render() {
         const { icon, iconPosition, showContent, url, target, rel } = this.props.attributes;

--- a/src/gutenberg/blocks/icon-box/edit.js
+++ b/src/gutenberg/blocks/icon-box/edit.js
@@ -53,6 +53,7 @@ class BlockEdit extends Component {
       iconColor,
       hoverIconColor,
       url,
+      ariaLabel,
       target,
       rel,
     } = attributes;
@@ -168,6 +169,7 @@ class BlockEdit extends Component {
         <URLPicker
           url={url}
           rel={rel}
+          ariaLabel={ariaLabel}
           target={target}
           onChange={(data) => {
             setAttributes(data);

--- a/src/gutenberg/blocks/icon-box/save.js
+++ b/src/gutenberg/blocks/icon-box/save.js
@@ -26,7 +26,7 @@ const { name } = metadata;
  */
 class BlockSave extends Component {
   render() {
-    const { icon, iconPosition, showContent, url, target, rel } = this.props.attributes;
+    const { icon, iconPosition, showContent, url, target, rel, ariaLabel } = this.props.attributes;
 
     let className = classnames('ghostkit-icon-box', url ? 'ghostkit-icon-box-with-link' : '');
 
@@ -45,6 +45,7 @@ class BlockSave extends Component {
             href={url}
             target={target || false}
             rel={rel || false}
+            aria-label={ariaLabel || ''}
           >
             <span />
           </a>

--- a/src/gutenberg/blocks/icon-box/save.js
+++ b/src/gutenberg/blocks/icon-box/save.js
@@ -49,9 +49,9 @@ class BlockSave extends Component {
           <a
             className="ghostkit-icon-box-link"
             href={url}
-            target={target || false}
-            rel={rel || false}
-            aria-label={ariaLabel || false}
+            target={target || null}
+            rel={rel || null}
+            aria-label={ariaLabel || null}
           >
             <span />
           </a>

--- a/src/gutenberg/blocks/icon-box/styles/style.scss
+++ b/src/gutenberg/blocks/icon-box/styles/style.scss
@@ -15,12 +15,17 @@
     position: relative;
   }
 
-  &-link span {
+  &-link {
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+    inset: 0;
+    
+    span {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
   }
 
   // Icon.

--- a/src/gutenberg/blocks/icon-box/styles/style.scss
+++ b/src/gutenberg/blocks/icon-box/styles/style.scss
@@ -15,17 +15,12 @@
     position: relative;
   }
 
-  &-link {
+  &-link span {
     position: absolute;
-    inset: 0;
-    
-    span {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-    }
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
   }
 
   // Icon.

--- a/src/gutenberg/blocks/testimonial/block.json
+++ b/src/gutenberg/blocks/testimonial/block.json
@@ -62,6 +62,10 @@
     "url": {
       "type": "string"
     },
+    "ariaLabel": {
+      "type": "string",
+      "default": ""
+    },
     "target": {
       "type": "string"
     },

--- a/src/gutenberg/blocks/testimonial/block.json
+++ b/src/gutenberg/blocks/testimonial/block.json
@@ -63,8 +63,7 @@
       "type": "string"
     },
     "ariaLabel": {
-      "type": "string",
-      "default": ""
+      "type": "string"
     },
     "target": {
       "type": "string"

--- a/src/gutenberg/blocks/testimonial/deprecated.js
+++ b/src/gutenberg/blocks/testimonial/deprecated.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 /**
  * External dependencies
  */
@@ -20,7 +21,191 @@ const { applyFilters } = wp.hooks;
 
 const { InnerBlocks, RichText } = wp.blockEditor;
 
+const { name } = metadata;
+
 export default [
+  // v2.23.2
+  {
+    ...metadata,
+    attributes: {
+      icon: {
+        type: 'string',
+        default:
+          '%3Csvg%20class%3D%22ghostkit-svg-icon%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M13.5954%2010.708C15.7931%205.55696%2021.1071%205%2021.1071%205L21.3565%205.16714C18.945%206.72641%2019.0559%208.98169%2019.0559%208.98169C19.0559%208.98169%2022.1211%209.70495%2022.7979%2012.2673C23.5186%2014.996%2022.2158%2017.2944%2020.4141%2018.3373C18.1801%2019.6305%2015.4248%2018.9499%2014.0389%2017.0008C12.6134%2014.996%2012.8469%2012.4623%2013.5954%2010.708Z%22%20fill%3D%22currentColor%22%2F%3E%3Cpath%20d%3D%22M1.59537%2010.708C3.79305%205.55696%209.10709%205%209.10709%205L9.35651%205.16714C6.945%206.72641%207.05592%208.98169%207.05592%208.98169C7.05592%208.98169%2010.1211%209.70495%2010.7979%2012.2673C11.5186%2014.996%2010.2158%2017.2944%208.41413%2018.3373C6.18005%2019.6305%203.42475%2018.9499%202.03887%2017.0008C0.61344%2014.996%200.846929%2012.4623%201.59537%2010.708Z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E',
+      },
+      photoId: {
+        type: 'number',
+      },
+      photoUrl: {
+        attribute: 'src',
+        selector: '.ghostkit-testimonial-photo img',
+        source: 'attribute',
+        type: 'string',
+      },
+      photoAlt: {
+        attribute: 'alt',
+        selector: '.ghostkit-testimonial-photo img',
+        source: 'attribute',
+        type: 'string',
+        default: '',
+      },
+      photoWidth: {
+        type: 'number',
+      },
+      photoHeight: {
+        type: 'number',
+      },
+      photoSizeSlug: {
+        type: 'string',
+      },
+      name: {
+        type: 'string',
+        source: 'html',
+        selector: '.ghostkit-testimonial-name',
+        default: '<strong>Katrina Craft</strong>',
+      },
+      source: {
+        type: 'string',
+        source: 'html',
+        selector: '.ghostkit-testimonial-source',
+        default: 'Designer',
+      },
+      stars: {
+        type: 'number',
+      },
+      starsIcon: {
+        type: 'string',
+        default:
+          '%3Csvg%20class%3D%22ghostkit-svg-icon%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M12.6724%202.66808C12.5461%202.41207%2012.2853%202.25%2011.9998%202.25C11.7144%202.25%2011.4536%202.41207%2011.3273%202.66808L8.56287%208.26941L2.38143%209.16762C2.09892%209.20868%201.86421%209.40656%201.77599%209.67807C1.68777%209.94958%201.76134%2010.2476%201.96577%2010.4469L6.4387%2014.8069L5.38279%2020.9634C5.33453%2021.2448%205.45019%2021.5291%205.68115%2021.6969C5.91211%2021.8647%206.21831%2021.8869%206.471%2021.754L11.9998%2018.8473L17.5287%2021.754C17.7814%2021.8869%2018.0876%2021.8647%2018.3185%2021.6969C18.5495%2021.5291%2018.6652%2021.2448%2018.6169%2020.9634L17.561%2014.8069L22.0339%2010.4469C22.2383%2010.2476%2022.3119%209.94958%2022.2237%209.67807C22.1355%209.40656%2021.9008%209.20868%2021.6183%209.16762L15.4368%208.26941L12.6724%202.66808Z%22%20fill%3D%22currentColor%22%2F%3E%3C%2Fsvg%3E',
+      },
+      url: {
+        type: 'string',
+      },
+      target: {
+        type: 'string',
+      },
+      rel: {
+        type: 'string',
+      },
+    },
+    save: class BlockSave extends Component {
+      render() {
+        const { attributes } = this.props;
+
+        const {
+          photoId,
+          photoUrl,
+          photoAlt,
+          photoWidth,
+          photoHeight,
+
+          icon,
+          source,
+          stars,
+          starsIcon,
+          url,
+          target,
+          rel,
+        } = attributes;
+
+        let className = classnames(
+          'ghostkit-testimonial',
+          url ? 'ghostkit-testimonial-with-link' : ''
+        );
+
+        className = applyFilters('ghostkit.blocks.className', className, {
+          ...{
+            name,
+          },
+          ...this.props,
+        });
+
+        return (
+          <div className={className}>
+            {url ? (
+              <a
+                className="ghostkit-testimonial-link"
+                href={url}
+                target={target || false}
+                rel={rel || false}
+              >
+                <span />
+              </a>
+            ) : (
+              ''
+            )}
+            {icon ? (
+              <IconPicker.Render name={icon} tag="div" className="ghostkit-testimonial-icon" />
+            ) : (
+              ''
+            )}
+            <div className="ghostkit-testimonial-content">
+              <InnerBlocks.Content />
+            </div>
+            {photoUrl ? (
+              <div className="ghostkit-testimonial-photo">
+                <img
+                  src={photoUrl}
+                  alt={photoAlt}
+                  className={photoId ? `wp-image-${photoId}` : null}
+                  width={photoWidth}
+                  height={photoHeight}
+                />
+              </div>
+            ) : (
+              ''
+            )}
+            {!RichText.isEmpty(attributes.name) || !RichText.isEmpty(source) ? (
+              <div className="ghostkit-testimonial-meta">
+                {!RichText.isEmpty(attributes.name) ? (
+                  <div className="ghostkit-testimonial-name">
+                    <RichText.Content value={attributes.name} />
+                  </div>
+                ) : (
+                  ''
+                )}
+                {!RichText.isEmpty(source) ? (
+                  <div className="ghostkit-testimonial-source">
+                    <RichText.Content value={source} />
+                  </div>
+                ) : (
+                  ''
+                )}
+              </div>
+            ) : (
+              ''
+            )}
+            {'number' === typeof stars && starsIcon ? (
+              <div className="ghostkit-testimonial-stars">
+                <div className="ghostkit-testimonial-stars-wrap">
+                  <div
+                    className="ghostkit-testimonial-stars-front"
+                    style={{ width: `${(100 * stars) / 5}%` }}
+                  >
+                    <IconPicker.Render name={starsIcon} />
+                    <IconPicker.Render name={starsIcon} />
+                    <IconPicker.Render name={starsIcon} />
+                    <IconPicker.Render name={starsIcon} />
+                    <IconPicker.Render name={starsIcon} />
+                  </div>
+                  <div className="ghostkit-testimonial-stars-back">
+                    <IconPicker.Render name={starsIcon} />
+                    <IconPicker.Render name={starsIcon} />
+                    <IconPicker.Render name={starsIcon} />
+                    <IconPicker.Render name={starsIcon} />
+                    <IconPicker.Render name={starsIcon} />
+                  </div>
+                </div>
+              </div>
+            ) : (
+              ''
+            )}
+          </div>
+        );
+      }
+    },
+  },
+
   // v2.20.3
   {
     ...metadata,
@@ -134,7 +319,7 @@ export default [
 
         className = applyFilters('ghostkit.blocks.className', className, {
           ...{
-            name: metadata.name,
+            name,
           },
           ...this.props,
         });

--- a/src/gutenberg/blocks/testimonial/edit.js
+++ b/src/gutenberg/blocks/testimonial/edit.js
@@ -117,6 +117,7 @@ class BlockEdit extends Component {
       starsIcon,
 
       url,
+      ariaLabel,
       target,
       rel,
     } = attributes;
@@ -249,6 +250,7 @@ class BlockEdit extends Component {
         <URLPicker
           url={url}
           rel={rel}
+          ariaLabel={ariaLabel}
           target={target}
           onChange={(data) => {
             setAttributes(data);

--- a/src/gutenberg/blocks/testimonial/save.js
+++ b/src/gutenberg/blocks/testimonial/save.js
@@ -40,6 +40,7 @@ class BlockSave extends Component {
       stars,
       starsIcon,
       url,
+      ariaLabel,
       target,
       rel,
     } = attributes;
@@ -59,9 +60,9 @@ class BlockSave extends Component {
           <a
             className="ghostkit-testimonial-link"
             href={url}
-            aria-label={ariaLabel || ''}
-            target={target || false}
-            rel={rel || false}
+            target={target || null}
+            rel={rel || null}
+            aria-label={ariaLabel || null}
           >
             <span />
           </a>

--- a/src/gutenberg/blocks/testimonial/save.js
+++ b/src/gutenberg/blocks/testimonial/save.js
@@ -59,6 +59,7 @@ class BlockSave extends Component {
           <a
             className="ghostkit-testimonial-link"
             href={url}
+            aria-label={ariaLabel || ''}
             target={target || false}
             rel={rel || false}
           >

--- a/src/gutenberg/components/url-picker/index.js
+++ b/src/gutenberg/components/url-picker/index.js
@@ -34,12 +34,13 @@ export default class URLPicker extends Component {
   }
 
   onChange(data) {
-    const { rel, target, url } = this.props;
+    const { rel, target, url, ariaLabel } = this.props;
 
     const newData = {
       rel,
       target,
       url,
+      ariaLabel,
       ...data,
     };
 
@@ -95,7 +96,7 @@ export default class URLPicker extends Component {
   }
 
   render() {
-    const { rel, toolbarSettings = true, inspectorSettings = true, isSelected } = this.props;
+    const { rel, ariaLabel, toolbarSettings = true, inspectorSettings = true, isSelected } = this.props;
 
     const { onChange } = this;
 
@@ -161,6 +162,15 @@ export default class URLPicker extends Component {
                 onChange={(val) => {
                   onChange({
                     rel: val,
+                  });
+                }}
+              />
+              <TextControl
+                label={__('Accessible Label')}
+                value={ariaLabel || ''}
+                onChange={(val) => {
+                  onChange({
+                    ariaLabel: val,
                   });
                 }}
               />


### PR DESCRIPTION
addresses #152 

This adds an accessible label control for the URLPicker component and includes the aria-label on all the blocks that use this component. 

Affected blocks:
- button single
- counter box
- icon box
- testimonial

This also updates the CSS for the icon box block link so that it is focusable. Currently it is impossible to navigate to the link in at least Safari with or without screen reader activated. 