### PR TITLE
only require form-block related files if the form-block is enabled

### DIFF
--- a/src/gutenberg/index.php
+++ b/src/gutenberg/index.php
@@ -14,19 +14,23 @@ require_once ghostkit()->plugin_path . 'gutenberg/blocks/instagram/block.php';
 require_once ghostkit()->plugin_path . 'gutenberg/blocks/twitter/block.php';
 require_once ghostkit()->plugin_path . 'gutenberg/blocks/table-of-contents/block.php';
 
-require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/block.php';
-require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/text/block.php';
-require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/email/block.php';
-require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/name/block.php';
-require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/url/block.php';
-require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/phone/block.php';
-require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/number/block.php';
-require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/date/block.php';
-require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/textarea/block.php';
-require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/select/block.php';
-require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/checkbox/block.php';
-require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/radio/block.php';
-require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/hidden/block.php';
+
+
+if ( ! $key_exists( 'ghostkit/form', get_option( 'ghostkit_disabled_blocks', array() ) ) ) {
+    require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/block.php';
+    require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/text/block.php';
+    require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/email/block.php';
+    require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/name/block.php';
+    require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/url/block.php';
+    require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/phone/block.php';
+    require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/number/block.php';
+    require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/date/block.php';
+    require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/textarea/block.php';
+    require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/select/block.php';
+    require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/checkbox/block.php';
+    require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/radio/block.php';
+    require_once ghostkit()->plugin_path . 'gutenberg/blocks/form/fields/hidden/block.php';
+}
 
 require_once ghostkit()->plugin_path . 'gutenberg/plugins/customizer/index.php';
 require_once ghostkit()->plugin_path . 'gutenberg/plugins/custom-code/index.php';


### PR DESCRIPTION
only require form-block related files if the form-block is enabled, to avoid the creation of the PHPSESSID-cookie (because of GPRD-things...)