### PR TITLE
Increase max value for slides from 20 to 100 due to a client request for more than 20 elements

### DIFF
--- a/src/gutenberg/blocks/carousel/edit.js
+++ b/src/gutenberg/blocks/carousel/edit.js
@@ -106,7 +106,7 @@ class BlockEdit extends Component {
               value={slidesCount}
               onChange={(value) => this.updateSlidesCount(value)}
               min={2}
-              max={20}
+              max={100}
               allowCustomMax
             />
           </PanelBody>


### PR DESCRIPTION
I have a client, who wants 23 elements in a carousel and it seems that it will be more and more but probably not more than 100 elements. Anyway, I think 20 is to less for a carousel in a specific case like for me. I dunno what performance issues can raise here so maybe there is smth due to this limitations of 20 but maybe you can tell me more about why you add max=20 to this. I would prefer to let the user decide to have more elements than 20 and if there is a performance problem, it should be somewhere written in the docs to let them know. But if they want more then we should give them the possibility for that.