### PR TITLE
fix(tests): derive the plugin dir instead of hardcoding it

### DIFF
--- a/tests/phpunit/unit/test-ghostkit-class.php
+++ b/tests/phpunit/unit/test-ghostkit-class.php
@@ -28,10 +28,23 @@ class GhostkitTest extends WP_UnitTestCase {
     }
 
 	/**
+	 * The plugin directory, derived from this file's own location.
+	 *
+	 * The plugin root cannot be hardcoded. Ghost Kit Pro vendors this plugin as
+	 * `core-plugin/` inside its own directory, so the absolute path differs
+	 * depending on which checkout is running the suite.
+	 *
+	 * @return string Absolute path, with a trailing slash.
+	 */
+	private function get_plugin_dir() {
+		return dirname( __DIR__, 3 ) . '/';
+	}
+
+	/**
 	 * Plugin Path test.
 	 */
 	public function test_plugin_path() {
-		$defined_path = '/var/www/html/wp-content/plugins/ghostkit/';
+		$defined_path = $this->get_plugin_dir();
 		$plugin_path = ghostkit()->plugin_path;
 
 		$this->assertEquals( $defined_path, $plugin_path );
@@ -46,7 +59,7 @@ class GhostkitTest extends WP_UnitTestCase {
 		// path to the plugins URL. Build the expectation with `plugins_url()` rather
 		// than hardcoding a host: the port is derived per checkout and is not always
 		// the default one.
-		$defined_url = plugins_url( '/var/www/html/wp-content/plugins/ghostkit/' );
+		$defined_url = plugins_url( $this->get_plugin_dir() );
 		$plugin_url = ghostkit()->plugin_url;
 
 		$this->assertEquals( $defined_url, $plugin_url );


### PR DESCRIPTION
`test_plugin_path` and `test_plugin_url` asserted the absolute path this plugin gets mounted at in its own `wp-env`:

```php
$defined_path = '/var/www/html/wp-content/plugins/ghostkit/';
```

That only holds here. Ghost Kit Pro vendors this plugin as `core-plugin/`, so it resolves to `/var/www/html/wp-content/plugins/ghostkit-pro/core-plugin/` there and both tests fail.

That has been invisible until now because ghostkit-pro's `phpunit.xml.dist` filtered on `suffix="-test.php"`, which matches none of our `test-*.php` files — none of this plugin's tests had ever run there. Fixing that collection (nk-crew/ghostkit-pro, in progress) surfaces these two immediately:

```
1) GhostkitTest::test_plugin_path
-'/var/www/html/wp-content/plugins/ghostkit/'
+'/var/www/html/wp-content/plugins/ghostkit-pro/core-plugin/'
```

## Change

Derive the directory from the test file's own location instead. Same assertion, but it holds wherever the plugin is mounted:

```php
private function get_plugin_dir() {
    return dirname( __DIR__, 3 ) . '/';
}
```

`dirname( $path, $levels )` is PHP 7.0+; this plugin requires 7.2.

This follows #234, which stopped `test_plugin_url` hardcoding `http://localhost:8889` for the same class of reason — the host part was per-checkout, and the path part turns out to be too.

## Verified

- This repo: `npm run test:unit:php` → 58 tests, 91 assertions, OK
- `vendor/bin/phpcs --standard=phpcs.xml.dist` on the changed file → clean
- ghostkit-pro with its collection fixed and this branch in place → the two failures go away (confirmed by probing the same expression against `ghostkit()->plugin_path`/`->plugin_url` under its bootstrap)