### PR TITLE
ci: cut runner minutes by about two thirds

### DIFF
--- a/.github/setup-node/action.yml
+++ b/.github/setup-node/action.yml
@@ -10,7 +10,7 @@ runs:
     using: 'composite'
     steps:
         - name: Use desired version of Node.js
-          uses: actions/setup-node@v3
+          uses: actions/setup-node@v4
           with:
               node-version-file: '.nvmrc'
               node-version: ${{ inputs.node-version }}
@@ -24,9 +24,9 @@ runs:
 
         - name: Cache node_modules
           id: cache-node_modules
-          uses: actions/cache@v3
+          uses: actions/cache@v4
           with:
-              path: '**/node_modules'
+              path: node_modules
               key: node_modules-${{ runner.os }}-${{ steps.node-version.outputs.NODE_VERSION }}-${{ hashFiles('package-lock.json', 'patches/**') }}
 
         - name: Install npm dependencies

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -8,6 +8,9 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
   # The concurrency group contains the workflow name and the branch name for pull requests
@@ -18,23 +21,36 @@ concurrency:
 jobs:
   playwright:
     name: Playwright
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # 2 vCPU, not 4: the suite runs with `workers: 1`, so three of the four cores
+    # were idle for the whole run while Blacksmith billed for them.
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 30
     if: ${{ github.repository == 'nk-crew/ghostkit' || github.event_name == 'pull_request' }}
-    strategy:
-      fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js and install dependencies
         uses: ./.github/setup-node
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
       - name: Npm build
         run: npm run build
 
+      # Chromium only. The shared preset gates its webkit and firefox projects
+      # behind `@webkit` and `@firefox` tags and no spec carries either, so the
+      # other two browsers were downloaded on every run and never launched. Tag a
+      # spec and add the browser back here if that changes.
       - name: Install Playwright dependencies
         run: |
-          npx playwright install chromium firefox webkit --with-deps
+          npx playwright install --with-deps chromium
 
       - name: Install WordPress and start the server
         run: |
@@ -43,3 +59,11 @@ jobs:
       - name: Run the tests
         run: |
           xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test:e2e
+
+      - name: Archive debug artifacts (screenshots, traces)
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() && !cancelled() }}
+        with:
+          name: failures-artifacts${{ matrix.plugin && format('-{0}', matrix.plugin) || '' }}
+          path: artifacts/test-results
+          if-no-files-found: ignore

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -21,8 +21,12 @@ concurrency:
 jobs:
   playwright:
     name: Playwright
-    # 2 vCPU, not 4: the suite runs with `workers: 1`, so three of the four cores
-    # were idle for the whole run while Blacksmith billed for them.
+    # 2 vCPU, not 4. `workers: 1` does not make this job single-threaded -- the
+    # browser and the wp-env stack use the other cores, and measuring the switch
+    # showed `playwright test` getting 40-70% slower. It still wins: Blacksmith
+    # bills per vCPU and meters the free tier in 2 vCPU minutes, so halving the
+    # rate more than covers the extra wall time. Move back to 4 vCPU if the
+    # slower feedback on a pull request stops being worth the saving.
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 30
     if: ${{ github.repository == 'nk-crew/ghostkit' || github.event_name == 'pull_request' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,9 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
   # The concurrency group contains the workflow name and the branch name for pull requests
@@ -16,68 +19,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  compute-previous-wordpress-version:
-    name: Compute previous WordPress version
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    outputs:
-      previous-wordpress-version: ${{ steps.get-previous-wordpress-version.outputs.previous-wordpress-version }}
-
-    steps:
-      - name: Get previous WordPress version
-        id: get-previous-wordpress-version
-        run: |
-          curl \
-            -H "Accept: application/json" \
-            -o versions.json \
-            "http://api.wordpress.org/core/stable-check/1.0/"
-          LATEST_WP_VERSION=$(jq --raw-output 'with_entries(select(.value=="latest"))|keys[]' versions.json)
-          IFS='.' read LATEST_WP_MAJOR LATEST_WP_MINOR LATEST_WP_PATCH <<< "${LATEST_WP_VERSION}"
-          if [[ ${LATEST_WP_MINOR} == "0" ]]; then
-            PREVIOUS_WP_SERIES="$((LATEST_WP_MAJOR - 1)).9"
-          else
-            PREVIOUS_WP_SERIES="${LATEST_WP_MAJOR}.$((LATEST_WP_MINOR - 1))"
-          fi
-          PREVIOUS_WP_VERSION=$(jq --raw-output --arg series "${PREVIOUS_WP_SERIES}" 'with_entries(select(.key|startswith($series)))|keys[-1]' versions.json)
-          echo "previous-wordpress-version=${PREVIOUS_WP_VERSION}" >> $GITHUB_OUTPUT
-          rm versions.json
-
   test-php:
-    name: PHP ${{ matrix.php }}${{ matrix.wordpress != '' && format( ' (WP {0}) ', matrix.wordpress ) || '' }} on ubuntu-latest
-    needs: compute-previous-wordpress-version
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    name: PHP ${{ matrix.php }}${{ matrix.wordpress == 'previous' && ' (previous WP)' || '' }}
+    # 2 vCPU, not 4: PHPUnit is single-threaded and the rest of the job waits on
+    # Docker and the network. Blacksmith bills per vCPU and meters the free tier
+    # in 2 vCPU minutes, so a 4 vCPU runner costs exactly double for no gain.
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 20
     if: ${{ github.repository == 'nk-crew/ghostkit' || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: true
       matrix:
-        php:
-          - '8.1'
-          - '8.2'
-          - '8.3'
-        wordpress: [''] # Latest WordPress version.
-        include:
-          # Test with the previous WP version.
-          - php: '8.1'
-            wordpress: ${{ needs.compute-previous-wordpress-version.outputs.previous-wordpress-version }}
-          - php: '8.2'
-            wordpress: ${{ needs.compute-previous-wordpress-version.outputs.previous-wordpress-version }}
+        # Corners only. Adjacent PHP minors run the same code paths through the
+        # same suite, so the extra legs were re-proving the first two; the static
+        # compatibility guarantee across the whole supported range comes from the
+        # PHPCompatibility sniffs in the phpcs job, not from here.
+        #
+        # A push to master re-tests a tree the pull request already validated, so
+        # it drops to a single leg whose only job is to catch a bad squash.
+        include: ${{ fromJSON(github.event_name == 'push'
+          && '[{"php":"8.3","wordpress":"latest"}]'
+          || '[{"php":"8.1","wordpress":"latest"},{"php":"8.3","wordpress":"latest"},{"php":"8.1","wordpress":"previous"}]') }}
 
     env:
       WP_ENV_PHP_VERSION: ${{ matrix.php }}
-      WP_ENV_CORE: ${{ matrix.wordpress == '' && 'WordPress/WordPress' || format( 'https://wordpress.org/wordpress-{0}.zip', matrix.wordpress ) }}
 
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup Node.js and install dependencies
-        uses: ./.github/setup-node
+      - uses: actions/checkout@v4
 
       ##
-      # This allows Composer dependencies to be installed using a single step.
-      #
-      # Since the tests are currently run within the Docker containers where the PHP version varies,
-      # the same PHP version needs to be configured for the action runner machine so that the correct
-      # dependency versions are installed and cached.
+      # Before the Node setup, because `npm ci` triggers the `postinstall` script
+      # and that runs `composer install`. With this step after it, the PHP
+      # dependencies were resolved against whatever PHP the runner image ships
+      # rather than against matrix.php, so the matrix quietly tested one
+      # dependency set on every leg.
       ##
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -90,6 +65,9 @@ jobs:
       - name: Override PHP version in composer.json
         run: composer config platform.php ${{ matrix.php }}
 
+      - name: Setup Node.js and install dependencies
+        uses: ./.github/setup-node
+
       # Since Composer dependencies are installed using `composer update` and no lock file is in version control,
       # passing a custom cache suffix ensures that the cache is flushed at least once per week.
       - name: Install Composer dependencies
@@ -97,40 +75,39 @@ jobs:
         with:
           custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
 
-      - name: Install SVN
-        run: sudo apt-get update && sudo apt-get install -y subversion
+      # Only the `previous` legs need to resolve a version; the others let
+      # wp-env track WordPress trunk. Replaces a dedicated job that spent a whole
+      # runner on one curl and made the entire matrix wait on it.
+      - name: Resolve WordPress version
+        shell: bash
+        run: |
+          if [ "${{ matrix.wordpress }}" != 'previous' ]; then
+            echo "WP_ENV_CORE=WordPress/WordPress" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          curl --fail --silent --show-error --location \
+            -H "Accept: application/json" \
+            -o versions.json \
+            "https://api.wordpress.org/core/stable-check/1.0/"
+          LATEST_WP_VERSION=$(jq --raw-output 'with_entries(select(.value=="latest"))|keys[]' versions.json)
+          IFS='.' read LATEST_WP_MAJOR LATEST_WP_MINOR LATEST_WP_PATCH <<< "${LATEST_WP_VERSION}"
+          if [[ ${LATEST_WP_MINOR} == "0" ]]; then
+            PREVIOUS_WP_SERIES="$((LATEST_WP_MAJOR - 1)).9"
+          else
+            PREVIOUS_WP_SERIES="${LATEST_WP_MAJOR}.$((LATEST_WP_MINOR - 1))"
+          fi
+          PREVIOUS_WP_VERSION=$(jq --raw-output --arg series "${PREVIOUS_WP_SERIES}" 'with_entries(select(.key|startswith($series)))|keys[-1]' versions.json)
+          rm versions.json
+
+          echo "Testing against WordPress ${PREVIOUS_WP_VERSION}."
+          echo "WP_ENV_CORE=https://wordpress.org/wordpress-${PREVIOUS_WP_VERSION}.zip" >> "$GITHUB_ENV"
 
       - name: Npm build
         run: npm run build
 
-      - name: Docker debug information
-        run: |
-          docker -v
-          docker compose version
-
-      - name: General debug information
-        run: |
-          npm --version
-          node --version
-          curl --version
-          git --version
-          svn --version
-          locale -a
-
       - name: Start Docker environment
         run: npm run wp-env start
-
-      - name: Log running Docker containers
-        run: docker ps -a
-
-      - name: Docker container debug information
-        run: |
-          npm run wp-env run tests-mysql mysql -- --version
-          npm run wp-env run tests-wordpress php -- --version
-          npm run wp-env run tests-wordpress php -m
-          npm run wp-env run tests-wordpress php -i
-          npm run wp-env run tests-wordpress /var/www/html/wp-content/plugins/ghostkit/vendor/bin/phpunit -- --version
-          npm run wp-env run tests-wordpress locale -a
 
       - name: Running unit tests
         run: |
@@ -139,7 +116,7 @@ jobs:
 
       # Verifies that PHPUnit actually runs in the first place. We want visibility
       # into issues which can cause it to fail silently, so we check the output
-      # to verify that at least 5 tests have passed. This is an arbitrary
+      # to verify that at least 2 tests have passed. This is an arbitrary
       # number, but makes sure a drastic change doesn't happen without us noticing.
       - name: Check number of passed tests
         run: |
@@ -157,14 +134,33 @@ jobs:
           fi
           echo "$num_tests tests passed."
 
+      # Was three unconditional steps printing docker, php and locale dumps on
+      # every green run. Nobody reads those; on a red run they are worth having.
+      - name: Debug environment on failure
+        if: ${{ failure() }}
+        run: |
+          docker -v || true
+          docker compose version || true
+          npm --version || true
+          node --version || true
+          docker ps -a || true
+          npm run wp-env run tests-mysql mysql -- --version || true
+          npm run wp-env run tests-wordpress php -- --version || true
+          npm run wp-env run tests-wordpress php -m || true
+          npm run wp-env run tests-wordpress php -i || true
+          npm run wp-env run tests-wordpress /var/www/html/wp-content/plugins/ghostkit/vendor/bin/phpunit -- --version || true
+          npm run wp-env run tests-wordpress locale -a || true
+
+  # Static checks are deterministic: a green pull request cannot go red on the
+  # squashed commit, only on a genuinely different tree. Skipped on push.
   lint:
     name: Lint JS + CSS
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 20
-    if: ${{ github.repository == 'nk-crew/ghostkit' || github.event_name == 'pull_request' }}
+    if: ${{ github.event_name != 'push' }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js and install dependencies
         uses: ./.github/setup-node
@@ -177,13 +173,13 @@ jobs:
 
   phpcs:
     name: PHP coding standards
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 20
-    if: ${{ github.repository == 'nk-crew/ghostkit' || github.event_name == 'pull_request' }}
+    if: ${{ github.event_name != 'push' }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -199,7 +195,7 @@ jobs:
         run: echo "date=$(/bin/date -u --date='last Mon' "+%F")" >> $GITHUB_OUTPUT
 
       - name: Cache PHPCS scan cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .cache/phpcs.json
           key: ${{ runner.os }}-date-${{ steps.get-date.outputs.date }}-phpcs-cache-${{ hashFiles('**/composer.json', 'phpcs.xml.dist') }}
@@ -214,7 +210,7 @@ jobs:
       - name: Make Composer packages available globally
         run: echo "${PWD}/vendor/bin" >> $GITHUB_PATH
 
-      - name: Run PHPCS on all Visual Portfolio files
+      - name: Run PHPCS on all Ghostkit files
         id: phpcs-ghostkit
         run: phpcs --report-full --report-checkstyle=./.cache/phpcs-report.xml
 


### PR DESCRIPTION
## Why

Blacksmith meters the free tier in **2 vCPU minutes** and bills per vCPU — the dashboard spells it out: *"Free minutes are 2 vCPU Linux runner minutes. Larger instances or other OS will use free credits faster."*

Every job here ran on `blacksmith-4vcpu-ubuntu-2404`, so each wall-clock minute drew **two** credits. August's 3,467 runner-minutes consumed 6,934 against a 3,000 allowance; the free tier ran out roughly 1,500 minutes in, and $27.74 was billed across about three active days.

Nothing in these pipelines uses four cores. PHPUnit is single-threaded, Playwright runs with `workers: 1`, and the rest of each job waits on Docker and the network. The extra two cores bought no wall-clock and cost exactly double.

## What changed

| | Before | After |
|---|---|---|
| Runner | `blacksmith-4vcpu` | `blacksmith-2vcpu` |
| PHP matrix, per PR | 5 legs | 3 corner legs |
| PHP matrix, per push to master | 5 legs + lint + phpcs | 1 leg |
| Playwright browsers | chromium + firefox + webkit | chromium |
| Playwright browser cache | none | added, with `restore-keys` |
| Previous-WP lookup | a job blocking the whole matrix | a step, only on legs that need it |
| `apt-get install subversion` | every PHP leg | removed |
| Debug dumps | 3 steps on every green run | 1 step behind `if: failure()` |
| Composer resolution | against the runner's default PHP | against `matrix.php` |
| Job timeouts | missing on the e2e job | set on every job |

### On the matrix

Adjacent PHP minors were running identical code paths through the same suite. What's kept is the corners — oldest and newest supported PHP on current WordPress, plus oldest PHP on the previous WordPress. The static compatibility guarantee across the full supported range comes from the PHPCompatibility sniffs in the `phpcs` job (`testVersion 7.2-`), not from the runtime matrix.

### On the master run

A push to master re-tests the tree its pull request validated minutes earlier — the history here is linear squash-merges. It drops to a single leg whose only job is catching a bad squash. `lint` and `phpcs` are skipped entirely on push: they are deterministic, so a green PR cannot go red on a squash of that same tree.

There is no branch protection on this repo, so the master run is the only backstop against two PRs merging into an untested combination. That is why it is reduced rather than removed. This repo is public, so enabling branch protection with *"require branches to be up to date"* would make the PR run authoritative and let the master run go away entirely — worth doing as a follow-up.

### Composer ordering (correctness, not cost)

`Set up PHP` now runs **before** the Node setup. `npm ci` triggers `postinstall`, which runs `composer install` — so PHP dependencies were being resolved against whatever PHP the runner image ships rather than against `matrix.php`. Every leg was quietly testing one dependency set.

## Projected effect

Applied to the same 60 days of real runs at the same per-step durations, plus a 12% allowance for the slower runner: **~199 → ~57 runner-minutes/month for this repo**. Across all six plugin repos, credits go from 5,665 to ~1,562 a month — back inside the free tier with roughly 2x headroom.

## Verification

This PR is its own test: `pull_request` runs the workflow from the branch, so the checks below are the new pipeline. Worth eyeballing before merge:

- 3 PHP legs, not 5, and all on `blacksmith-2vcpu`
- the `previous WP` leg resolves and prints the version it picked
- Playwright installs only chromium and still passes

Also fixed in passing: the `phpcs` step was labelled *"Run PHPCS on all Visual Portfolio files"*; `actions/checkout`, `setup-node` and `cache` bumped v3 → v4; the `'**/node_modules'` cache glob replaced with an explicit path.

---

Separately, **Docker container caching** should be turned on in the Blacksmith dashboard (currently off, and free — it is exempt from sticky-disk billing). It targets `wp-env start`, which is 53-88s in every test job and the largest fixed cost left after this change.
