### PR TITLE
fix(e2e): make the runtime-error tests able to fail, drop a save race

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,9 +165,9 @@ jobs:
       - name: Setup Node.js and install dependencies
         uses: ./.github/setup-node
 
-      - name: Npm build
-        run: npm run build
-
+      # No `npm run build` here. `lint:js` is `biome check`, and the shared
+      # Biome config excludes `**/build`; `lint:css` globs the `assets` sources
+      # directly. Neither reads a single file the build produces.
       - name: Running the lint
         run: npm run lint
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
 				"@babel/preset-env": "^7.23.9",
 				"@babel/register": "^7.23.7",
 				"@biomejs/biome": "2.5.7",
-				"@nk-crew/plugin-toolkit": "^0.5.1",
+				"@nk-crew/plugin-toolkit": "^0.6.0",
 				"@playwright/test": "^1.45.3",
 				"@wordpress/e2e-test-utils-playwright": "^1.4.0",
 				"@wordpress/env": "^10.4.0",
@@ -3566,9 +3566,9 @@
 			}
 		},
 		"node_modules/@nk-crew/plugin-toolkit": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/@nk-crew/plugin-toolkit/-/plugin-toolkit-0.5.1.tgz",
-			"integrity": "sha512-NMNVIZKcwQ6oRu6mSEjpOcme72s6n7f+nzRk9c+rinfjFnr1khB9tZJmLNrjBR1kE1l6FpArXLOWm4nvtZ6Ivg==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@nk-crew/plugin-toolkit/-/plugin-toolkit-0.6.0.tgz",
+			"integrity": "sha512-KU9IwgzP8JP9Ra4rlE9UI4OOn8JhHdmyMHhmWDq3DjfuFbIio+STRBlbmxVe/jLEsycESWBoHt1vdR1AH9b5mw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"@babel/preset-env": "^7.23.9",
 		"@babel/register": "^7.23.7",
 		"@biomejs/biome": "2.5.7",
-		"@nk-crew/plugin-toolkit": "^0.5.1",
+		"@nk-crew/plugin-toolkit": "^0.6.0",
 		"@playwright/test": "^1.45.3",
 		"@wordpress/e2e-test-utils-playwright": "^1.4.0",
 		"@wordpress/env": "^10.4.0",

--- a/tests/e2e/specs/gist-block.spec.js
+++ b/tests/e2e/specs/gist-block.spec.js
@@ -73,7 +73,22 @@ async function mockGistResponses(target, stylesheetUrl) {
 	return stats;
 }
 
-async function publishAndGetFrontendPage(page, editor) {
+/**
+ * Publishes the post and opens its frontend.
+ *
+ * `onPageReady` runs against the new page *before* it navigates. That ordering
+ * is the whole point: Playwright does not buffer `console` or `pageerror` for
+ * listeners attached later, and `goto` resolves on `load`, which already waited
+ * for the async plugin scripts to execute. A listener attached after this
+ * function returned could never see an error thrown during script evaluation --
+ * which is exactly the error these specs exist to catch.
+ *
+ * @param {Object}   page        Playwright page holding the editor.
+ * @param {Object}   editor      Block editor utils.
+ * @param {Function} onPageReady Called with the frontend page before it loads.
+ * @return {Object} The frontend page.
+ */
+async function publishAndGetFrontendPage(page, editor, onPageReady) {
 	await editor.publishPost();
 
 	const viewPageButton = page
@@ -86,14 +101,17 @@ async function publishAndGetFrontendPage(page, editor) {
 
 	if (href) {
 		const frontendPage = await page.context().newPage();
+		onPageReady?.(frontendPage);
+		// No `waitForLoadState('domcontentloaded')` after this: `goto` resolves
+		// on `load`, which is strictly later, so the wait was a no-op.
 		await frontendPage.goto(href);
-		await frontendPage.waitForLoadState('domcontentloaded');
 		return frontendPage;
 	}
 
 	const popupPromise = page.waitForEvent('popup', { timeout: 3000 });
 	await viewPageButton.click();
 	const popupPage = await popupPromise;
+	onPageReady?.(popupPage);
 	await popupPage.waitForLoadState('domcontentloaded');
 
 	return popupPage;
@@ -143,13 +161,15 @@ test.describe('gist block', () => {
 			},
 		});
 
-		await page.waitForTimeout(1000);
-
 		await expect(
 			editor.canvas.locator('.ghostkit-gist').first()
 		).toBeVisible();
-		await expect(mockStats.jsonRequests).toBeGreaterThan(0);
-		await expect(mockStats.cssRequests).toBeGreaterThan(0);
+		// `expect.poll`, not `expect`: `mockStats` is a plain object the route
+		// handlers mutate, so a bare `expect` reads it once with no retry. That
+		// is why a flat 1s sleep used to sit above this -- polling ends as soon
+		// as the mock has fired instead.
+		await expect.poll(() => mockStats.jsonRequests).toBeGreaterThan(0);
+		await expect.poll(() => mockStats.cssRequests).toBeGreaterThan(0);
 
 		const relevantErrors = runtimeErrors.filter(
 			(message) =>
@@ -191,16 +211,28 @@ test.describe('gist block', () => {
 			},
 		});
 
-		const frontendPage = await publishAndGetFrontendPage(page, editor);
-		const runtimeErrors = trackRuntimeErrors(frontendPage);
-
-		await frontendPage.waitForTimeout(1000);
+		// Attached through the callback so the listeners exist before the page
+		// navigates. Attaching them to the returned page, as this did, meant the
+		// script had already run and any error was long gone -- `runtimeErrors`
+		// was always empty and the assertion below could not fail.
+		let runtimeErrors = [];
+		const frontendPage = await publishAndGetFrontendPage(
+			page,
+			editor,
+			(frontend) => {
+				runtimeErrors = trackRuntimeErrors(frontend);
+			}
+		);
 
 		await expect(
 			frontendPage.locator('.ghostkit-gist').first()
 		).toBeVisible();
-		await expect(mockStats.jsonRequests).toBeGreaterThan(0);
-		await expect(mockStats.cssRequests).toBeGreaterThan(0);
+		// `expect.poll`, not `expect`: `mockStats` is a plain object the route
+		// handlers mutate, so a bare `expect` reads it once with no retry. That
+		// is why a flat 1s sleep used to sit above this -- polling ends as soon
+		// as the mock has fired instead.
+		await expect.poll(() => mockStats.jsonRequests).toBeGreaterThan(0);
+		await expect.poll(() => mockStats.cssRequests).toBeGreaterThan(0);
 
 		const relevantErrors = runtimeErrors.filter(
 			(message) =>

--- a/tests/e2e/specs/lottie-block.spec.js
+++ b/tests/e2e/specs/lottie-block.spec.js
@@ -61,7 +61,22 @@ async function mockLottieResponse(target) {
 	});
 }
 
-async function publishAndGetFrontendPage(page, editor) {
+/**
+ * Publishes the post and opens its frontend.
+ *
+ * `onPageReady` runs against the new page *before* it navigates. That ordering
+ * is the whole point: Playwright does not buffer `console` or `pageerror` for
+ * listeners attached later, and `goto` resolves on `load`, which already waited
+ * for the async plugin scripts to execute. A listener attached after this
+ * function returned could never see an error thrown during script evaluation --
+ * which is exactly the error these specs exist to catch.
+ *
+ * @param {Object}   page        Playwright page holding the editor.
+ * @param {Object}   editor      Block editor utils.
+ * @param {Function} onPageReady Called with the frontend page before it loads.
+ * @return {Object} The frontend page.
+ */
+async function publishAndGetFrontendPage(page, editor, onPageReady) {
 	await editor.publishPost();
 
 	const viewPageButton = page
@@ -74,14 +89,17 @@ async function publishAndGetFrontendPage(page, editor) {
 
 	if (href) {
 		const frontendPage = await page.context().newPage();
+		onPageReady?.(frontendPage);
+		// No `waitForLoadState('domcontentloaded')` after this: `goto` resolves
+		// on `load`, which is strictly later, so the wait was a no-op.
 		await frontendPage.goto(href);
-		await frontendPage.waitForLoadState('domcontentloaded');
 		return frontendPage;
 	}
 
 	const popupPromise = page.waitForEvent('popup', { timeout: 3000 });
 	await viewPageButton.click();
 	const popupPage = await popupPromise;
+	onPageReady?.(popupPage);
 	await popupPage.waitForLoadState('domcontentloaded');
 
 	return popupPage;
@@ -164,8 +182,18 @@ test.describe('lottie block', () => {
 			},
 		});
 
-		const frontendPage = await publishAndGetFrontendPage(page, editor);
-		const runtimeErrors = trackRuntimeErrors(frontendPage);
+		// Attached through the callback so the listeners exist before the page
+		// navigates. Attaching them to the returned page, as this did, meant the
+		// script had already run and any error was long gone -- `runtimeErrors`
+		// was always empty and the assertion below could not fail.
+		let runtimeErrors = [];
+		const frontendPage = await publishAndGetFrontendPage(
+			page,
+			editor,
+			(frontend) => {
+				runtimeErrors = trackRuntimeErrors(frontend);
+			}
+		);
 
 		await expect(
 			frontendPage.locator('lottie-player').first()

--- a/tests/e2e/specs/typography.spec.js
+++ b/tests/e2e/specs/typography.spec.js
@@ -56,10 +56,24 @@ test.describe('typography', () => {
 
 		await fontInput.fill(font);
 
+		// Wait for the save, not for a guess at how long it takes. The settings
+		// page debounces by exactly 1000ms and then fires the POST without
+		// awaiting it, so `waitForTimeout(1000)` expired as the request was
+		// being issued -- and the `page` fixture closes the page at teardown,
+		// discarding anything still in flight. When it lost that race the
+		// symptom appeared in a later test, as a font mismatch.
+		//
+		// Registered before the keypress: the response is a second away, but the
+		// listener still has to exist before the thing that triggers it.
+		const saved = page.waitForResponse(
+			(response) =>
+				response.url().includes('update_custom_typography') &&
+				response.request().method() === 'POST'
+		);
+
 		await fontInput.press('Enter');
 
-		// Just wait 1 second for the selected font to be saved in the database after selection.
-		await page.waitForTimeout(1000);
+		await saved;
 
 		return wrapper;
 	}


### PR DESCRIPTION
Toolkit 0.6.0 plus the fixes that came out of profiling this suite. **Two of these are tests that currently cannot fail** — those matter more than the seconds.

## The runtime-error tests never observe the errors they exist to catch

`lottie-block.spec.js` and `gist-block.spec.js` both do:

```js
const frontendPage = await publishAndGetFrontendPage(page, editor);
const runtimeErrors = trackRuntimeErrors(frontendPage);   // ← too late
```

`publishAndGetFrontendPage` does `newPage()` → `goto(href)`. Playwright does not buffer `console` or `pageerror` for listeners attached afterwards, and `goto` resolves on `load` — which has already waited for the `async` plugin scripts to both load *and execute* (`classes/class-assets.php:413-414`). So an error thrown during script evaluation was emitted and dropped before the listener existed.

`relevantErrors` was therefore always `[]`, and `expect(relevantErrors).toEqual([])` always passed.

The lottie one is the regression test for the duplicate `customElements.define('lottie-player', …)` fix. As written it would not catch a reintroduction.

The helper now takes an `onPageReady` callback and hands the page over before navigating.

**Heads up for review:** these two assertions have never actually run. If either now goes red, that is a real finding, not a broken test — the whole point of the change is that they can fail again.

## The typography save is a race it loses

`setFontSetting` slept 1000 ms for a save the settings page debounces by **exactly** 1000 ms (`settings/pages/typography.js:28-31`) and then fires without awaiting (`:254-260`). The sleep expired as the POST was going out, and the `page` fixture closes the page at teardown, discarding anything in flight.

When it lost, the symptom appeared in a *different* test — `Check fonts available on backend and frontend` — as a mismatch against `EXPECTED_GOOGLE_FONTS_FAMILY`. Classic intermittent-and-baffling.

It now waits on the POST itself. No time saved; the 1000 ms is in the product.

## The gist counters were asserted without retry

`await expect(mockStats.jsonRequests).toBeGreaterThan(0)` — `mockStats` is a plain object the route handlers mutate, so `await` on a non-thenable buys nothing and the check ran once. That is precisely why a flat 1 s sleep had to sit in front of it. `expect.poll` retries and ends as soon as the mock fires.

Both sleeps (editor and frontend) are gone. ~1.6 s.

## Smaller

- Two `waitForLoadState('domcontentloaded')` calls that ran *after* `goto` had resolved on `load` — strictly later, so no-ops.
- The build step is gone from the `lint` job. `lint:js` is `biome check`, and the shared Biome config excludes `**/build`; `lint:css` globs the SCSS sources. Neither reads anything the build produces. 8–15 s per PR.
- `@nk-crew/plugin-toolkit` → `0.6.0` ([toolkit#2](https://github.com/nk-crew/plugin-toolkit/pull/2)): no tracing on tests that pass, and `reportSlowTests` restored so the next run prints its own slowest files.

Lockfile touched surgically — four fields for that one package. `npm install --package-lock-only` re-resolves the whole tree and, on a sibling repo, dropped two optional peers while flipping ~60 entries to `dev`.

## Sleeps deliberately kept

`console-errors.spec.js:100` and the two in `lottie-block.spec.js` are settle windows for the *absence* of a future event. There is no signal for "no error is coming", so a sleep is the correct tool.

## Flagged, not fixed

`ghostkit_typography` is never reset. wp-env's database survives `env:stop`, so from the second run onward every editor boot enqueues a real `fonts.googleapis.com` stylesheet inside the `load` gate — which is likely why `console-errors.spec.js` has to ignore `/fonts\.gstatic\.com/i` and `/net::ERR_/i`. Test 4 also silently depends on tests 1–3 having run, so `--grep` on it alone fails.

I did not fix it: the obvious reset via `update_custom_typography` **merges** rather than replaces (`classes/class-rest.php:1834-1856`), so `{}` lands as `[]`, and getting it right needs a local run.

Also flagged: `publishAndGetFrontendPage` and `trackRuntimeErrors` are copy-pasted across three spec files, which is why this fix had to be applied twice. Worth a `tests/e2e/utils/` directory like the sibling plugins have.

## Not included

`assets-loading.spec.js` boots the editor and publishes six times to produce content REST could create (est. 15–30 s). Detection is content-driven, so it should be equivalent — but it would stop the markup round-tripping through the editor's parse/serialize, and that wants a local run first.