### PR TITLE
chore(dev): add worktree config

### DIFF
--- a/.claude/worktree.json
+++ b/.claude/worktree.json
@@ -1,0 +1,14 @@
+{
+  "bootstrap": "npx --yes --package=@nk-crew/plugin-toolkit nk-worktree-setup --no-env",
+  "servers": [
+    {
+      "name": "dev",
+      "command": "npm run dev"
+    }
+  ],
+  "checks": [
+    "npm run lint",
+    "npm run test:unit:php",
+    "npm run test:e2e"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ yarn-error.log*
 .spec/
 .phpcs.xml
 phpcs.xml
+
+# Per-checkout worktrees and dev launch config (see .claude/worktree.json)
+.claude/worktrees/
+.claude/launch.json


### PR DESCRIPTION
A fresh `git worktree` has no node_modules, no composer vendor directory and no submodules, so every new branch needed the same manual setup by hand. `.claude/worktree.json` records how to bootstrap one and points at `nk-worktree-setup` from `@nk-crew/plugin-toolkit` — already a dependency here — rather than repeating the steps.

WordPress stays down on purpose: the bootstrap runs with `--no-env`, so creating a worktree costs an install and nothing more, and `npm run env:start` brings the containers up when they are actually needed. wp-env keys its instance on the checkout path and takes a free port pair in a linked worktree, so no ports are pinned in this file.

`.gitignore` gains the per-checkout state — the worktrees directory and the generated launch config. The config file itself is shared and committed.

Nothing in the build, the plugin or CI reads this file.
